### PR TITLE
Pin pydata-sphinx-theme to 0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,36 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.6.0]
+        additional_dependencies: [black==23.1.0]
         args: [-l, '79', -t, py38]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
     - id: pydocstyle
       additional_dependencies: [toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,9 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "spherex-sphinx"
 description = "Sphinx configurations and extensions for SPHEREx."
-license = {file = "LICENSE"}
-readme= "README.md"
-keywords = [
-    "spherex",
-    "sphinx",
-]
+license = { file = "LICENSE" }
+readme = "README.md"
+keywords = ["spherex", "sphinx"]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -23,7 +20,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "Sphinx>=5",
-    "pydata-sphinx-theme>=0.10.0",
+    "pydata-sphinx-theme>=0.10.0,<0.13.0",
     "sphinx_design",
     "sphinx-autodoc-typehints",
     "sphinx-automodapi",
@@ -50,11 +47,7 @@ dev = [
 Source = "https://github.com/SPHEREx/spherex-sphinx"
 
 [build-system]
-requires = [
-    "setuptools>=61",
-    "wheel",
-    "setuptools_scm[toml]>=6.2"
-]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -83,7 +76,7 @@ exclude_lines = [
     "raise NotImplementedError",
     "if 0:",
     "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:"
+    "if TYPE_CHECKING:",
 ]
 
 [tool.black]
@@ -108,7 +101,7 @@ exclude = '''
 # Reference: http://www.pydocstyle.org/en/stable/error_codes.html
 convention = "numpy"
 add_select = [
-    "D212" # Multi-line docstring summary should start at the first line
+    "D212", # Multi-line docstring summary should start at the first line
 ]
 add-ignore = [
     "D105", # Missing docstring in magic method
@@ -130,10 +123,7 @@ known_first_party = ["spherexsphinx", "tests"]
 skip = ["docs/conf.py"]
 
 [tool.pytest.ini_options]
-python_files = [
-    "tests/*.py",
-    "tests/*/*.py"
-]
+python_files = ["tests/*.py", "tests/*/*.py"]
 
 [tool.mypy]
 disallow_untyped_defs = true


### PR DESCRIPTION
The new release of the pydata-sphinx-theme creates an extra warning when setting up light/dark logos from files installed via `static_html_path`. This pin is to prevent that warning temporarily while we understand the change see how it may be updated in the future.