### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "sphinx-autodoc-typehints",
     "sphinx-automodapi",
     "sphinx-copybutton",
+    "sphinxcontrib-jquery",
     "myst-parser",
     "markdown-it-py[linkify]",
     "sphinxcontrib-mermaid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "markdown-it-py[linkify]",
     "sphinxcontrib-mermaid",
     "tomli; python_version < \"3.11\"",
-    "pydantic",
+    "pydantic < 2.0.0",
 ]
 dynamic = ["version"]
 

--- a/src/spherexsphinx/conf/base.py
+++ b/src/spherexsphinx/conf/base.py
@@ -48,6 +48,7 @@ default_role = "py:obj"
 # Extensions =================================================================
 
 extensions = [
+    "sphinxcontrib.jquery",
     "myst_parser",
     "sphinx_design",
     "sphinx_copybutton",


### PR DESCRIPTION
- Pin pydantic < 2.0.0
- Adopt [sphinxcontrib.jquery](https://github.com/sphinx-contrib/jquery) since Sphinx no longer ships jquery with sites by default. This restore functionality like the search bar.
