### PR TITLE
Add defusedxml test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "beautifulsoup4",
     "lxml",
     "types-docutils",
+    "defusedxml", # Required by Sphinx testing module
 ]
 
 [project.urls]


### PR DESCRIPTION
defusedxml is used by the sphinx.testing subpackage, but is not a dependency of Sphinx itself right now. Therefore for us to use the pytest fixtures in sphinx.testing, we need to include defusedxml as a test dependency for spherex-sphinx.