### PR TITLE
Configure GitHub edit link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "sphinxcontrib-mermaid",
     "tomli; python_version < \"3.11\"",
     "pydantic > 2.0, < 3.0",
+    "GitPython",
 ]
 dynamic = ["version"]
 

--- a/src/spherexsphinx/conf/_utils.py
+++ b/src/spherexsphinx/conf/_utils.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
+from git import Repo
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 from sphinx.errors import ConfigError
 
@@ -55,8 +58,8 @@ class ProjectModel(BaseModel):
 
     title: str = Field(
         description=(
-            "Name of the project, used as titles throughout the documentation "
-            "site."
+            "Name of the project, used as titles throughout the "
+            "documentation site."
         )
     )
 
@@ -166,6 +169,45 @@ class SpherexConfig:
         """
         extensions.extend(self.config.sphinx.extensions)
 
+    def set_edit_on_github(
+        self,
+        html_theme_options: MutableMapping[str, Any],
+        html_context: MutableMapping[str, Any],
+    ) -> None:
+        """Configures the Edit on GitHub functionality, if possible."""
+        if self.github_url is None:
+            raise ConfigError("project.github_url is not set.")
+
+        parsed_url = urlparse(self.github_url)
+        path_parts = parsed_url.path.split("/")
+        try:
+            # first part is "/"
+            github_owner = path_parts[1]
+            github_repo = path_parts[2].split(".")[0]  # drop .git if present
+        except IndexError:
+            raise ConfigError(
+                f"Could not parse GitHub repo URL: {self.github_url}"
+            )
+
+        repo = GitRepository(Path.cwd())
+        try:
+            # the current working directory for sphinx config is always
+            # the same as the directory containing the conf.py file.
+            doc_dir = str(Path.cwd().relative_to(repo.working_tree_dir))
+        except ValueError:
+            raise ConfigError(
+                "Cannot determine the path of the documentation directory "
+                "relative to the Git repository root."
+            )
+
+        html_theme_options["use_edit_page_button"] = True
+        html_context["github_user"] = github_owner
+        html_context["github_repo"] = github_repo
+        html_context[
+            "github_version"
+        ] = self.config.project.github_default_branch
+        html_context["doc_path"] = doc_dir
+
     @classmethod
     def load(cls) -> SpherexConfig:
         """Load the spherex.toml file from the current directory.
@@ -185,3 +227,20 @@ class SpherexConfig:
             )
             raise ConfigError(message)
         return cls(config=config)
+
+
+class GitRepository:
+    """Access to to metadata about the Git repository of the documentation
+    project.
+    """
+
+    def __init__(self, dirname: Path) -> None:
+        self._repo = Repo(dirname, search_parent_directories=True)
+
+    @property
+    def working_tree_dir(self) -> Path:
+        """The root directory of the Git repository."""
+        path = self._repo.working_tree_dir
+        if path is None:
+            raise RuntimeError("Git repository is not available.")
+        return Path(path)


### PR DESCRIPTION
Add a SphinxConfig.set_edit_on_github method that configures the theme's edit-on-GitHub functionality. The configuration uses the repository link in the configuration TOML file in conjunction with tooling built on GitPython to determine the path of the documentation project relative to the root of the Git repository.