### PR TITLE
Support for setting nitpick_ignore and ignore warnings around Pydantic API links by default.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,3 @@ and can be extended by setting additional variables after the import.
 """
 
 from spherexsphinx.conf.base import *
-
-nitpick_ignore = [
-    ("py:.*", "pydantic.*"),
-]

--- a/docs/user-guide/spherex-toml.rst
+++ b/docs/user-guide/spherex-toml.rst
@@ -69,6 +69,38 @@ A list of `Sphinx extensions <https://www.sphinx-doc.org/en/master/usage/extensi
 Note that you will need to include additional extension packages in your project's Python dependencies.
 You may also need to configure the additional extensions in your project's :file:`conf.py` file.
 
+.. _toml-sphinx-nitpick_ignore:
+
+sphinx.nitpick_ignore
+---------------------
+
+A list of Sphinx warnings to suppress. Each item is a two-item list, where the first item is the role/domain type and the second item is the target, such as the Python API.
+For more information, see the `Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore>`__.
+
+.. code-block:: toml
+   :caption: spherex.toml
+
+   [sphinx]
+   nitpick_ignore = [
+       ["py:class", "BaseModel"]
+   ]
+
+sphinx.nitpick_ignore_regex
+---------------------------
+
+A list of Sphinx warnings to suppress, using regular expressions to match both the type and target of the warning (see :ref:`toml-sphinx-nitpick-ignore`). For more information, see the `Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore_regex>`__.
+
+.. code-block:: toml
+   :caption: spherex.toml
+
+   [sphinx]
+   nitpick_ignore_regex = [
+       ['py:.*', 'pydantic.*']
+   ]
+
+Note that TOML strings with single backticks are treated as literal strings (with no automatic escaping).
+This is useful for regular expressions, where backslashes are common.
+
 [sphinx.intersphinx.projects]
 =============================
 

--- a/src/spherexsphinx/conf/_utils.py
+++ b/src/spherexsphinx/conf/_utils.py
@@ -64,7 +64,7 @@ class ProjectModel(BaseModel):
     )
 
     base_url: Optional[HttpUrl] = Field(
-        description="Canonical URL of the site's root page."
+        None, description="Canonical URL of the site's root page."
     )
 
     copyright: str = Field(
@@ -75,7 +75,7 @@ class ProjectModel(BaseModel):
     )
 
     github_url: Optional[HttpUrl] = Field(
-        description="The URL of the project's GitHub repository."
+        None, description="The URL of the project's GitHub repository."
     )
 
     github_default_branch: str = Field(
@@ -176,7 +176,8 @@ class SpherexConfig:
     ) -> None:
         """Configures the Edit on GitHub functionality, if possible."""
         if self.github_url is None:
-            raise ConfigError("project.github_url is not set.")
+            html_theme_options["use_edit_page_button"] = False
+            return
 
         parsed_url = urlparse(self.github_url)
         path_parts = parsed_url.path.split("/")

--- a/src/spherexsphinx/conf/_utils.py
+++ b/src/spherexsphinx/conf/_utils.py
@@ -111,6 +111,23 @@ class SphinxModel(BaseModel):
         default_factory=list,
     )
 
+    nitpick_ignore: List[Tuple[str, str]] = Field(
+        description=(
+            "Errors to ignore. First item is the type (like a role or "
+            "directive) and the second is the target (like the argument to "
+            "the role)."
+        ),
+        default_factory=list,
+    )
+
+    nitpick_ignore_regex: List[Tuple[str, str]] = Field(
+        description=(
+            "Same as ``nitpick_ignore``, but both type and target are "
+            "interpreted as regular expressions."
+        ),
+        default_factory=list,
+    )
+
 
 class ConfigRoot(BaseModel):
     """Root of the spherex.toml configuration file."""

--- a/src/spherexsphinx/conf/base.py
+++ b/src/spherexsphinx/conf/base.py
@@ -71,12 +71,7 @@ c.extend_sphinx_extensions(extensions)
 html_theme = "pydata_sphinx_theme"
 
 # Jinja templating context
-html_context: Dict[str, Any] = {
-    "github_user": "SPHEREx",
-    "github_repo": "spherex-sphinx",
-    "github_version": "main",
-    "doc_path": "docs",
-}
+html_context: Dict[str, Any] = {}
 
 # Optional for the PyData Sphinx Theme
 html_theme_options: Dict[str, Any] = {
@@ -97,6 +92,8 @@ html_theme_options: Dict[str, Any] = {
         }
     ],
 }
+
+c.set_edit_on_github(html_theme_options, html_context)
 
 if c.github_url:
     html_theme_options["icon_links"].append(

--- a/src/spherexsphinx/conf/base.py
+++ b/src/spherexsphinx/conf/base.py
@@ -45,6 +45,21 @@ pygments_style = "sphinx"
 # The reST default role cross-links Python (used for this markup: `text`)
 default_role = "py:obj"
 
+# Ignore unavoidable Sphinx warnings.
+# Pydantic cross links aren't possible, so ignore them.
+nitpick_ignore_regex = [
+    ("py:.*", "pydantic.*"),
+]
+nitpick_ignore_regex.extend(c.config.sphinx.nitpick_ignore_regex)
+
+nitpick_ignore = [
+    ("py:class", "unittest.mock.Base"),
+    ("py:class", "unittest.mock.CallableMixin"),
+    ("py:class", "pydantic.BaseModel"),
+    ("py:class", "BaseModel"),
+]
+nitpick_ignore.extend(c.config.sphinx.nitpick_ignore)
+
 # Extensions =================================================================
 
 extensions = [

--- a/tests/roots/test-crossref/spherex.toml
+++ b/tests/roots/test-crossref/spherex.toml
@@ -2,6 +2,5 @@
 title = "SPHEREx Sphinx"
 copyright = "2022 California Institute of Technology"
 base_url = "https://spherex-docs.ipac.caltech.edu/spherex-sphinx/"
-github_url = "https://github.com/SPHEREx/spherex-sphinx"
 
 [sphinx.intersphinx]


### PR DESCRIPTION
This makes it possible to set nitpick_ignore and nitpick_ignore_regex in
spherex.toml. Also provides useful defaults for these configurations that
ignores links that cannot be resolved to Pydantic APIs that aren't available in intersphinx.