### PR TITLE
Work around type changes in beautifulsoup4

### DIFF
--- a/tests/ext/crossref_test.py
+++ b/tests/ext/crossref_test.py
@@ -24,7 +24,8 @@ def test_example_page_rendering(app: Sphinx, status: IO, warning: IO) -> None:
 
     # Simple link
     simple_section = soup.find(id="simple")
-    simple_link = simple_section.select("a.external")[0]
+    assert simple_section is not None
+    simple_link = simple_section.select("a.external")[0]  # type: ignore
     assert (
         simple_link["href"]
         == "https://spherex-docs.ipac.caltech.edu/ssdc-ms-001"
@@ -33,7 +34,8 @@ def test_example_page_rendering(app: Sphinx, status: IO, warning: IO) -> None:
 
     # Custom display
     custom_section = soup.find(id="custom-display")
-    custom_link = custom_section.select("a.external")[0]
+    assert custom_section is not None
+    custom_link = custom_section.select("a.external")[0]  # type: ignore
     assert (
         custom_link["href"]
         == "https://spherex-docs.ipac.caltech.edu/ssdc-ms-002"


### PR DESCRIPTION
The typing in beautifulsoup4 changed such that `select` is not being recognized as a attribute of the result of a `find` method. I think this is a bug in bs4 because the unit test still runs. The only workaround seems to be ignoring these type errors for now.

In other words, this PR resolves a CI issue. This isn't an issue that end-users would see.